### PR TITLE
Add scripts to format and create article markdown from contentful 

### DIFF
--- a/config/hugo.config.toml
+++ b/config/hugo.config.toml
@@ -25,6 +25,7 @@ paginate = 9
     appid = ""
 
 [taxonomies]
+  author = "author"
   category = "categories"
   tag = "tags"
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -10,13 +10,11 @@ const definePlugin = new webpack.DefinePlugin({
   }
 })
 
-let extractSCSS = new ExtractTextPlugin('css/[name].css'/*, {allChunks: true}*/);
 let extractLESS = new ExtractTextPlugin('css/[name]-less.css'/*, {allChunks: true}*/);
 
 
 module.exports = {
     entry: [
-        __dirname + '/../src/sass/style.scss',
         __dirname + '/../src/less/importer.less',
         __dirname + '/../src/js/main.js',
     ],
@@ -39,21 +37,12 @@ module.exports = {
                 }
             },
             {
-                test: /\.scss$/,
-                loader: extractSCSS.extract({
-                fallback: 'style-loader',
-                //resolve-url-loader may be chained before sass-loader if necessary
-                use: ['css-loader', 'sass-loader']
-              })
-            },
-            {
               test: /\.less$/i,
               use: extractLESS.extract([ 'css-loader', 'less-loader' ])
             }
         ]
     },
     plugins: [
-        extractSCSS,
         extractLESS,
         new webpack.ProvidePlugin({
             Promise: 'imports?this=>global!exports?global.Promise!es6-promise',

--- a/hugo/layouts/_default/article_card_preview.html
+++ b/hugo/layouts/_default/article_card_preview.html
@@ -1,0 +1,18 @@
+<div class="article-preview col-xs-12 col-sm-4" data-100-bottom-top="transform: translate3d(0px,25%,0px)" data-bottom-bottom="transform: translate3d(0px,0%,0px)">
+  <a href={{ .Permalink }}>
+    <div class="article-photo">
+      <img src={{ .Params.image }} />
+    </div>
+    <div class="author-photo">
+      <img src={{ .Params.image }} />
+    </div>
+    <div class="article-preview-text">
+      <div class="article-category">
+        {{ range .Params.categories }}
+        <a href="{{ $.Site.LanguagePrefix }}/categories/{{ . | urlize }}">{{ . }}</a>&nbsp; {{ end }}
+      </div>
+      <div class="article-title">{{ .Params.title }}</div>
+      <div class="author-name">By {{ .Params.author }}</div>
+    </div>
+  </a>
+</div>

--- a/hugo/layouts/_default/featured_article.html
+++ b/hugo/layouts/_default/featured_article.html
@@ -1,0 +1,22 @@
+<a href={{ .Permalink }}>
+  <div class="featured-preview">
+    <!-- Loop through posts and find featured article -->
+    <div class="article-photo" style="background-image: url({{ .Params.image }});"></div>
+    <div class="featured-preview-text">
+      <div>
+        <div class="featured-category-icon"></div>
+        <div class="featured-category">Hot Read of the Day</div>
+      </div>
+      <div class="article-container">
+        <div class="article-title">{{ .Params.title }}</div>
+        <div class="article-description">{{ .Title }}</div>
+      </div>
+      <div class="author-container">
+        <div class="author-photo">
+          <img src={{ .Params.image }}>
+        </div>
+        <div class="author-name">By {{ .Params.author }}</div>
+      </div>
+    </div>
+  </div>
+</a>

--- a/hugo/layouts/_default/single.html
+++ b/hugo/layouts/_default/single.html
@@ -14,7 +14,7 @@
     </div>
 
     <div role="main" id="article-body">
-      {{ .Content }}
+      {{ .Content | markdownify }}
     </div>
     <div class="post-article">
       {{ partial "article_post_article.html" . }}

--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -2,28 +2,7 @@
 <div role="main" id="advice-home">
   <div id="featured-container">
     {{ $pag := .Paginate (where .Data.Pages "Type" "post") }} {{ range $pag.Pages }} {{ if .Params.featured }}
-    <a href={{ .Permalink }}>
-      <div class="featured-preview">
-        <!-- Loop through posts and find featured article -->
-        <div class="article-photo" style="background-image: url({{ .Params.image }});"></div>
-        <div class="featured-preview-text">
-          <div>
-            <div class="featured-category-icon"></div>
-            <div class="featured-category">Hot Read of the Day</div>
-          </div>
-          <div class="article-container">
-            <div class="article-title">{{ .Params.title }}</div>
-            <div class="article-description">{{ .Title }}</div>
-          </div>
-          <div class="author-container">
-            <div class="author-photo">
-              <img src={{ .Params.image }}>
-            </div>
-            <div class="author-name">By {{ .Params.author }}</div>
-          </div>
-        </div>
-      </div>
-    </a>
+      {{ .Render "featured_article" }}
     {{ end }} {{ end }}
   </div>
   <div class="container-fluid">
@@ -38,24 +17,7 @@
       <div id="recent-articles">
         <div class="recent-artices">
           {{ $pag := .Paginate (where .Data.Pages "Type" "post") }} {{ range $pag.Pages }}
-            <div class="article-preview col-xs-12 col-sm-4" data-100-bottom-top="transform: translate3d(0px,25%,0px)" data-bottom-bottom="transform: translate3d(0px,0%,0px)">
-              <a href={{ .Permalink }}>
-                <div class="article-photo">
-                  <img src={{ .Params.image }} />
-                </div>
-                <div class="author-photo">
-                  <img src={{ .Params.image }} />
-                </div>
-                <div class="article-preview-text">
-                  <div class="article-category">
-                    {{ range .Params.categories }}
-                    <a href="{{ $.Site.LanguagePrefix }}/categories/{{ . | urlize }}">{{ . }}</a>&nbsp; {{ end }}
-                  </div>
-                  <div class="article-title">{{ .Params.title }}</div>
-                  <div class="author-name">By {{ .Params.author }}</div>
-                </div>
-              </a>
-            </div>
+            {{ .Render "article_card_preview" }}
           {{ end }}
         </div>
       </div>

--- a/hugo/layouts/partials/article_author_section.html
+++ b/hugo/layouts/partials/article_author_section.html
@@ -4,7 +4,11 @@
   </div>
   <div class="-info-container">
     <div class="-name">{{ .Params.author }}</div>
-    <div class="-bio">Author Bio</div>
+    <div class="-bio">
+      {{ range .Params.bio }}
+        {{ . | markdownify }}
+      {{ end }}
+    </div>
 
     <div class="-social-links-container">
       {{ if .Params.facebook }}

--- a/hugo/lib/createArticle.js
+++ b/hugo/lib/createArticle.js
@@ -46,9 +46,8 @@ module.exports = (entry) => {
 +++\n
 ${cleanBody}
 `;
-
   // Render content into the markdown template
-  return fs.writeFile(`../content/post/${filename}.md`, templateData, function(err) {
+  return fs.writeFile( __dirname+`/../content/post/${filename}.md`, templateData, function(err) {
     if (err) {
       console.log(err)
     }

--- a/hugo/lib/createArticle.js
+++ b/hugo/lib/createArticle.js
@@ -1,0 +1,56 @@
+const moment = require('moment');
+const marked = require('marked');
+const fs = require('fs');
+
+module.exports = (entry) => {
+  let content = entry.fields;
+
+  // Grab Article information used build template meta data
+  let {
+    title,
+    body,
+    date,
+    category,
+    tags,
+    slug,
+    description
+  } = content;
+  let type = 'article';
+  let cleanTitle = title.replace(/\"/g, '\\"');
+  let cleanDescription = description.replace(/\"/g, '\\"');
+  let cleanBody = marked(body);
+  let headerPhotoInfo = content.headerPhoto.fields;
+
+  // Grab Author information
+  let {bio, name} = content.author.fields;
+  let authorImageInfo = content.author.fields.picture.fields;
+
+  // Use title for the filename. Lowercase, replace ' ' with '-', and only keep alphanumeric characters
+  let filename;
+  if (slug) {
+    filename = slug;
+  } else {
+    filename = title.toLowerCase().replace(/\ /g, '-').replace(/[^0-9a-zA-Z_-]/g, '');
+  }
+  // create markdown. There has to be a way to do this better
+  const templateData = `+++
+  date = "${moment(date).format()}"
+  title = "${cleanTitle}"
+  categories = ["${category}"]
+  image = "${headerPhotoInfo.file.url}"
+  authorImage = "${authorImageInfo.file.url}"
+  featured = false
+  tags = ${JSON.stringify(tags)}
+  author = "${name}"
+  bio = ['${marked(bio)}']
++++\n
+${cleanBody}
+`;
+
+  // Render content into the markdown template
+  return fs.writeFile(`../content/post/${filename}.md`, templateData, function(err) {
+    if (err) {
+      console.log(err)
+    }
+  });
+}

--- a/hugo/lib/getArticles.js
+++ b/hugo/lib/getArticles.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const contentful = require('contentful');
+const createArticle = require('./createArticle');
+let cms;
+
+/**
+* Establish connection to contentful
+* get all article entries and create markdown file
+*/
+
+
+if (process.env.CONTENTFUL_SPACE_ID && process.env.CONTENTFUL_ACCESS_TOKEN) {
+  cms = contentful.createClient({
+    space: process.env.CONTENTFUL_SPACE_ID,
+    accessToken: process.env.CONTENTFUL_ACCESS_TOKEN,
+  });
+}
+
+cms.getEntries({ content_type: 'article' })
+.then(function (entries) {
+  entries.items.forEach(entry => {
+    // Take article and create  markdown template
+    createArticle(entry)
+  })
+})
+.catch(err => (console.error(err)));

--- a/package.json
+++ b/package.json
@@ -29,10 +29,12 @@
   },
   "dependencies": {
     "chalk": "^1.1.3",
+    "contentful": "^4.4.2",
     "es6-docready": "^1.0.0",
     "es6-promise": "^4.0.5",
     "html-webpack-plugin": "^2.28.0",
     "jquery": "^3.2.1",
+    "marked": "^0.3.6",
     "moment": "^2.18.1",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
     "extract-text-webpack-plugin": "^2.1.0",
     "less": "^2.3.1",
     "less-loader": "^4.0.4",
-    "node-sass": "^4.5.2",
     "postcss-loader": "^2.0.5",
-    "sass-loader": "^6.0.5",
     "style-loader": "^0.18.1",
     "webpack": "^2.5.1"
   },
@@ -39,7 +37,6 @@
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-ga": "^2.2.0",
-    "react-redux": "^4.4.6",
     "redux": "^3.6.0",
     "whatwg-fetch": "^2.0.0"
   },


### PR DESCRIPTION
#### What's this PR do?
Added scripts to create hugo content from contentful after every rebuild
Fixed markdown bug involving warping <p> tags.


#### How was this/how should this be reviewed?
Look through the hugo/lib directory the major changes are there.
I anticipate most of the single.html and index.html will change a lot after we get Kim's new designs so I wouldn't spend too much time there.

#### What are the relevant tickets?
issue: #1 

#### Questions/Considerations
The markdown fix works but if you know of a better solution to wrapping <p> tags. I tried two solutions. extracting all p tags from markdown before passing it to Hugo or using the "marked" library to pre-render it before it gets to Hugo. The first solution looks funky. 
