### PR TITLE
added progressive loader to main page

### DIFF
--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -1,9 +1,11 @@
 {{ define "main" }}
 <div role="main" id="advice-home">
   <div id="featured-container">
-    {{ $pag := .Paginate (where .Data.Pages "Type" "post") }} {{ range $pag.Pages }} {{ if .Params.featured }}
-      {{ .Render "featured_article" }}
-    {{ end }} {{ end }}
+    {{ range where .Site.Pages "Section" "==" "post" }}
+      {{ if .Params.featured }}
+        {{ .Render "featured_article" }}
+      {{ end }}
+    {{ end }}
   </div>
   <div class="container-fluid">
     <div class="row">
@@ -16,7 +18,7 @@
     <div class="row">
       <div id="recent-articles">
         <div class="recent-artices">
-          {{ $pag := .Paginate (where .Data.Pages "Type" "post") }} {{ range $pag.Pages }}
+          {{ range where .Site.Pages "Section" "==" "post" }}
             {{ .Render "article_card_preview" }}
           {{ end }}
         </div>

--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -1,8 +1,10 @@
 <!-- Importing bundled Javascript && createing dom element for react footer -->
 <div id="footer">
 </div>
-
+<script
+  src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 <script src='{{ "js/bundle.js" | relURL }}'></script>
+<script src='{{ "scripts/read-more.js" | relURL }}'></script>
 
 
 {{- partial "footer_custom.html" . }}

--- a/hugo/layouts/partials/includes.html
+++ b/hugo/layouts/partials/includes.html
@@ -1,6 +1,5 @@
 <link rel="canonical" href="{{ .URL | absLangURL }}" />
 <link rel="alternate" href="{{ "index.xml" | absLangURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
-<link rel='stylesheet' href='{{ "css/main.css" | relURL }}'>
 <link rel='stylesheet' href='{{ "css/main-less.css" | relURL }}'>
 <link href="https://fonts.googleapis.com/css?family=Caveat+Brush" rel="stylesheet" type="text/css">
 <link href="https://fonts.googleapis.com/css?family=Karla:400,400i,700" rel="stylesheet" type="text/css">

--- a/hugo/static/scripts/read-more.js
+++ b/hugo/static/scripts/read-more.js
@@ -1,0 +1,10 @@
+$(function () {
+    $(".article-preview").slice(0, 9).show();
+    $("#read-more").on('click', function (e) {
+        e.preventDefault();
+        $(".article-preview:hidden").slice(0, 9).slideDown();
+        if ($(".article-preview:hidden").length == 0) {
+            $("#load").fadeOut('slow');
+        }
+    });
+});

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "hugo-build": "hugo --config=config/hugo.config.toml --destination=public",
     "hugo-server": "hugo server --config=config/hugo.config.toml --verbose --destination=public",
     "webpack-server": "webpack-dev-server --config=config/webpack.config.js --port=8282 --watch --debug --verbose --progress --colors",
-    "webpack-watcher": "webpack --config=config/webpack.config.js --watch --debug --progress --colors",
-    "webpack-build": "webpack --config=config/webpack.config.js"
+    "webpack-watcher": "webpack --config=config/webpack.config.js --watch --debug --progress --colors -p",
+    "webpack-build": "webpack --config=config/webpack.config.js -p"
   },
   "devDependencies": {
     "babel-core": "^6.24.1",

--- a/src/less/articles.less
+++ b/src/less/articles.less
@@ -117,6 +117,7 @@
  * Smaller preview display of an article
  */
 .article-preview {
+  display: none;
   margin: @margin-sm 0;
 
   a {


### PR DESCRIPTION
#### What's this PR do?
Adds a progressive loader to main page. 

#### How was this/how should this be reviewed?
The script in the hugo/static/scripts/load-more.js is where the logic is handled
In hugo/layouts/index I changed the logic from rendering just the paginate amount to render all pages marked post/article

#### What are the relevant tickets?
issue #10 

#### Questions/Considerations
While this works, it is inefficient. Loading all of the images is blocking the website. Leveraging browser caching for the shutterstock images is an option. 
