### PR TITLE
test fix to baseurl for progressive loader

### DIFF
--- a/config/hugo.config.toml
+++ b/config/hugo.config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://advice-staging.shinetext.com"
 title = "Get Advice | Shine"
 
 contentdir = "hugo/content"


### PR DESCRIPTION
#### What's this PR do?
Test for progressive loader& baseURL. 
The progressive loader depends on the extra/paginator.html and its ability to grab the next page in the category or post list. But the base url in staging does not reflect the location of the posts. This pr is just so I can have a view of a deploy without merging. 