### PR TITLE
Adds og and twitter meta tags for social sharing

### DIFF
--- a/hugo/layouts/partials/extra/meta_og.html
+++ b/hugo/layouts/partials/extra/meta_og.html
@@ -5,7 +5,7 @@
 <meta property="og:description" content="{{ . }}" />
 {{- end }}
 {{- with .Params.image }}
-<meta property="og:image" content="{{ . }}?w=1200" />
+<meta property="og:image" content="https:{{ . }}?w=1200" />
 {{- end }}
 <meta property="og:url" content="{{ .Site.BaseURL }}{{ .URL }}" />
 <meta property="og:site_name" content="Shine" />

--- a/hugo/layouts/partials/extra/meta_og.html
+++ b/hugo/layouts/partials/extra/meta_og.html
@@ -1,0 +1,11 @@
+{{- with .Title | default .Site.Title }}
+<meta property="og:title" content="{{ . }}" />
+{{- end }}
+{{- with .Params.description }}
+<meta property="og:description" content="{{ . }}" />
+{{- end }}
+{{- with .Params.image }}
+<meta property="og:image" content="{{ . }}?w=1200" />
+{{- end }}
+<meta property="og:url" content="{{ .Site.BaseURL }}{{ .URL }}" />
+<meta property="og:site_name" content="Shine" />

--- a/hugo/layouts/partials/extra/meta_twitter.html
+++ b/hugo/layouts/partials/extra/meta_twitter.html
@@ -5,7 +5,7 @@
 <meta property="twitter:description" content="{{ . }}" />
 {{- end }}
 {{- with .Params.image }}
-<meta property="twitter:image" content="{{ . }}?w=1200" />
+<meta property="twitter:image" content="https:{{ . }}?w=1200" />
 {{- end }}
 <meta property="twitter:card" content="summary_large_image" />
 <meta property="twitter:site" content="@ShineText" />

--- a/hugo/layouts/partials/extra/meta_twitter.html
+++ b/hugo/layouts/partials/extra/meta_twitter.html
@@ -1,0 +1,11 @@
+{{- with .Title | default .Site.Title }}
+<meta property="twitter:title" content="{{ . }}" />
+{{- end }}
+{{- with .Params.description }}
+<meta property="twitter:description" content="{{ . }}" />
+{{- end }}
+{{- with .Params.image }}
+<meta property="twitter:image" content="{{ . }}?w=1200" />
+{{- end }}
+<meta property="twitter:card" content="summary_large_image" />
+<meta property="twitter:site" content="@ShineText" />

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -4,13 +4,16 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 <!-- Site Title, Description and Favicon -->
+
 {{- with .Title | default .Site.Title }}
   <title>{{ . }}</title>
-  <meta property="og:title" content="{{ . }}" />
 {{- end }}
+{{- partial "extra/meta_og.html" . }}
+{{- partial "extra/meta_twitter.html" . }}
+
 {{- with .Site.Params.favicon }}
   <link href='{{ . | absURL }}' rel='icon' type='image/x-icon'/>
-{{- end -}}
+{{- end }}
 {{- with .Site.Params.fb_app_id }}
   <meta property="fb:app_id" content="{{ . }}" />
 {{- end }}

--- a/hugo/lib/createArticle.js
+++ b/hugo/lib/createArticle.js
@@ -10,7 +10,7 @@ module.exports = entry => {
   let idxOfPubExMod = body.indexOf('<div class="pubexchange_module"'); // index of the pub exchange module in article body
   let type = 'article';
   let cleanTitle = title.replace(/\"/g, '\\"');
-  let cleanDescription = description.replace(/\"/g, '\\"');
+  let cleanDescription = description.replace(/\"/g, '\\"').trim();
   let cleanBody = marked(body.slice(0, idxOfPubExMod)); // slice pubexchange off of article body
   let headerPhotoInfo = content.headerPhoto.fields;
 
@@ -39,6 +39,7 @@ module.exports = entry => {
   const templateData = `+++
   date = "${moment(date).format()}"
   title = "${cleanTitle}"
+  description = "${cleanDescription}"
   categories = ["${category}"]
   image = "${headerPhotoInfo.file.url}"
   authorImage = "${authorImageInfo.file.url}"

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -68,12 +68,6 @@ class Header extends Component {
               <a href="/">
                 Get Advice{' '}
               </a>
-              <i
-                className="fa fa-plus plus-icon"
-                onClick={() => {
-                  $('#category-submenu').slideToggle();
-                }}
-              />
               <ul id="category-submenu">
                 <li><a href="/categories/hustle">HUSTLE</a></li>
                 <li><a href="/categories/life">LIFE</a></li>

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -68,10 +68,17 @@ class Header extends Component {
               <a href="/">
                 Get Advice{' '}
               </a>
+              <i
+                className="fa fa-plus plus-icon"
+                onClick={() => {
+                  $('#category-submenu').slideToggle();
+                }}
+              />
               <ul id="category-submenu">
+                <li><a href="/categories/chill">CHILL</a></li>
+                <li><a href="/categories/grow">GROW</a></li>
                 <li><a href="/categories/hustle">HUSTLE</a></li>
-                <li><a href="/categories/life">LIFE</a></li>
-                <li><a href="/categories/work">WORK</a></li>
+                <li><a href="/categories/play">PLAY</a></li>
               </ul>
             </li>
             <li>


### PR DESCRIPTION
#### What's this PR do?
- Updates the `createArticle` step to include the content description in the article template.
- Adds an `og` and `twitter` section to the `head` of the page that gets populated by the content's param values.
- ~Removes an extra plus-icon in the mobile menu. This isn't meant to be there is it?~
![screen shot 2017-07-03 at 3 08 22 pm](https://user-images.githubusercontent.com/696595/27805263-bce53916-6001-11e7-90ef-1bd8020c6694.png)
- UPDATE: jk, adding that icon back in. Just updating the mobile menu categories to reflect the 4 we're launching with.


#### How was this tested?
Fetched content for staging and ran a local server. Verified the tags were there and populated with the article's content.

#### Questions / Considerations
After deploy we'll want to test the staging links at least again the Twitter and Facebook card validators.
- https://cards-dev.twitter.com/validator
- https://developers.facebook.com/tools/debug/
