### PR TITLE
Adds slug to the generated article content

### DIFF
--- a/hugo/lib/createArticle.js
+++ b/hugo/lib/createArticle.js
@@ -40,6 +40,7 @@ module.exports = entry => {
   date = "${moment(date).format()}"
   title = "${cleanTitle}"
   description = "${cleanDescription}"
+  slug = "${slug}"
   categories = ["${category}"]
   image = "${headerPhotoInfo.file.url}"
   authorImage = "${authorImageInfo.file.url}"


### PR DESCRIPTION
#### What's this PR do?
Fixes scenarios where the slug is different than what the article title would've normally generated.

A couple cases where this was seen happening was for:
- /articles/how-this-shine-squad-member-stopped-comparing-himself-to-others
- /articles/shine-squad-feature-ninas-4-tips-to-slow-down-and-enjoy-life/

Without this change the articles instead would've been:
- /articles/shine-squad-feature-how-i-stopped-comparing-myself/
- /articles/4-tips-to-slow-down-and-enjoy-life/

It looked like without the slug, Hugo would generate the URL path based on the `title` as opposed to the filename. Does it make sense that that's what happening?

#### How was this tested? How should this be reviewed?
Tested the above 2 articles and their URL paths, plus several others on a local environment.