### PR TITLE
first paragraph fix

### DIFF
--- a/hugo/layouts/_default/single.html
+++ b/hugo/layouts/_default/single.html
@@ -13,7 +13,7 @@
       </div>
     </div>
     <div role="main" id="article-body">
-      {{ .Content | markdownify }}
+      {{ .Content }}
     </div>
     <div class="post-article">
       {{ partial "article_modules/article_post_article.html" . }}

--- a/hugo/lib/createArticle.js
+++ b/hugo/lib/createArticle.js
@@ -11,7 +11,8 @@ module.exports = entry => {
   let type = 'article';
   let cleanTitle = title.replace(/\"/g, '\\"');
   let cleanDescription = description.replace(/\"/g, '\\"').trim();
-  let cleanBody = marked(body.slice(0, idxOfPubExMod)); // slice pubexchange off of article body
+  let cleanBody = marked(body).slice(0, idxOfPubExMod); // slice pubexchange off of article body
+
   let headerPhotoInfo = content.headerPhoto.fields;
 
   // Grab Author information


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug involving Hugo's markdown parser and p tags. Removed markdown parsing from Hugo single template. 

#### How was this tested? How should this be reviewed?
Locally after fetching all the blog articles and removing the ``` {{ .Content | Markdownify }} ``` maked wraps the content in a p tag.

#### What are the relevant tickets?
Bug found when testing staging for production

#### Questions / Considerations
Painful but nessecary. 
