### PR TITLE
Fixes content at bottom of the article getting cut off

### DIFF
--- a/hugo/lib/createArticle.js
+++ b/hugo/lib/createArticle.js
@@ -11,8 +11,7 @@ module.exports = entry => {
   let type = 'article';
   let cleanTitle = title.replace(/\"/g, '\\"');
   let cleanDescription = description.replace(/\"/g, '\\"').trim();
-  let cleanBody = marked(body).slice(0, idxOfPubExMod); // slice pubexchange off of article body
-
+  let cleanBody = marked(body.slice(0, idxOfPubExMod)); // slice pubexchange off of article body
   let headerPhotoInfo = content.headerPhoto.fields;
 
   // Grab Author information


### PR DESCRIPTION
#### What's this PR do?
Fixes a previous change that caused extra content at the bottom of the article from getting cut off.

We'd get the index of the pubx module, if any here:
```
let idxOfPubExMod = body.indexOf('<div class="pubexchange_module"');
```

But then we'd render the `body` from markdown first and then remove content second here:
```
marked(body).slice(0, idxOfPubExMod);
```

We still need to slice off the pubx code first before parsing the markdown.

#### How was this tested? How should this be reviewed?
Verified content in Contentful matches up with what ends up getting rendered.

#### Considerations
We should probably consider removing the Pub Exchange code from the content body of all the articles and just leaving it to the template to take care of it. Removing it will simplify the logic we've got going on in createArticle.js.

cc: @kaladin9017 