### PR TITLE
fix safari browser bug

### DIFF
--- a/src/less/blog-v2/includes/latest-articles.less
+++ b/src/less/blog-v2/includes/latest-articles.less
@@ -157,13 +157,13 @@
   }
 
   .latest-articles-second-half {
-    height: 100%;
     margin-right: @margin-sm;
     flex: 1;
     -webkit-flex: 1;
     justify-content: space-around;
 
     .card {
+      flex-grow: 1;
       .card-container {
         flex-direction: column;
       }


### PR DESCRIPTION
#### What's this PR do?
Fix bug with safari and setting height of flexbox child to 100%. Removed height and changed it to use flex grow instead. 

#### How was this tested? How should this be reviewed?
Using safari 10. 

#### Questions / Considerations
I didn't use an autoprefixer for the less/css something to think about for any other browser compatibility.
