### PR TITLE
add script to create promoted json feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ hugo/data/path/manifest.json
 hugo/content/author/*
 hugo/content/author/*.test.md
 hugo/content/post/*
+hugo/static/promoted.json
 hugo/content/post/*.test.md
 config/hugo.config.toml

--- a/hugo/lib/createPromotedJson.js
+++ b/hugo/lib/createPromotedJson.js
@@ -1,0 +1,18 @@
+const fs = require('fs')
+
+/**
+ * Write Promoted articles to a json file in hugo/static directory
+ * can be found at baseURL/promoted.json
+*/
+
+module.exports = (articles) => {
+  return fs.writeFile(
+    __dirname + '/../static/promoted.json',
+    JSON.stringify(articles),
+    function(err) {
+      if (err) {
+        console.log(err);
+      }
+    }
+  );
+}


### PR DESCRIPTION
#### What's this PR do?
Create a json feed with 6 articles for http://advice.shinetext.com/promoted.json

#### How was this tested? How should this be reviewed?
Tested on my local to ensure each article had fields used in the ejs template to render the html feed

#### What are the relevant tickets?
#13

#### Questions / Considerations
I used an additional try catch instead of the same block. Not 100% sure but I didn't want an error in building the promoted feed to impact the rebuild on the main blog. 
