### PR TITLE
Adds _headers file to enable CORS on the promoted.json file

### DIFF
--- a/hugo/static/_headers
+++ b/hugo/static/_headers
@@ -1,0 +1,6 @@
+##
+## Custom headers when hosted on Netlify
+##
+
+/promoted.json
+  Access-Control-Allow-Origin: *


### PR DESCRIPTION
#### What's this PR do?
Adds _headers file to enable CORS on the promoted.json file. The promoted.json file is fetched by the Shine homepage on a different subdomain.

#### How was this tested?
Was testing with a local version of aurora. Ensured that the setup on localhost could fetch the promoted.json file on the deploy preview version created by this PR.

#### What are the relevant tickets?
#67 

#### Considerations
After this we can then make the update in [aurora](github.com/shinetext/aurora) to use the promoted.json here again.

cc: @cl2205 