### PR TITLE
update build script to only update production articles to promoted json

### DIFF
--- a/hugo/lib/getArticles.js
+++ b/hugo/lib/getArticles.js
@@ -96,6 +96,7 @@ Promise.coroutine(function*() {
       skip: 0,
       order: '-sys.createdAt',
       'fields.promoted': true,
+      'fields.publishTo[production]': true,
     };
     // query contentful for latest articles for shinetext article feed
     let promotedEntries = yield cms.getEntries(promotedQuery);


### PR DESCRIPTION
#### What's this PR do?
Update the promoted Json file to only include articles that have been published to staging.

#### How was this tested? How should this be reviewed?
Tested locally by running build scripts and then inspecting ``` promoted.json ``` file.

#### What are the relevant tickets?
No issue just a bug

#### Questions / Considerations
N/A