### PR TITLE
Increases max height of the article image to 540px from 412px

### DIFF
--- a/hugo/layouts/_default/single.html
+++ b/hugo/layouts/_default/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div id="shine-article">
   <div class="container-header">
-    <img class="-bgImage" src="{{ .Params.image }}?w=1440"/>
+    <img class="-bgImage" src="{{ .Params.image }}?w=1920"/>
   </div>
   <div class="main-article-content" style='padding-left:0;padding-right:0;background-color:white; margin-bottom:80px;'>
     <div class="pre-article-content">

--- a/src/less/blog-v2/variables/sizes.less
+++ b/src/less/blog-v2/variables/sizes.less
@@ -23,7 +23,7 @@
 @featured-article-preview-size: 400px;
 
 /* Advice page constants */
-@article-header-height: 412px;
+@article-header-height: 540px;
 @article-preview-height: 360px;
 @featured-author-photo-size: 70px;
 @featured-container-height: 450px;


### PR DESCRIPTION
#### What's this PR do?
Like the title says, just increases the height of that article image. This only applies to desktop view widths.

Increasing the height helps the majority of the images we're choosing for the articles work in both the homepage/card views and in the bigger view at the top of the article page. And in turn helps save our time on the content side when trying to find photos that'll work in the different views.

#### How was this tested? How should this be reviewed?
Just did some local testing. Screenshots below to highlight the difference

**412px:**
![screen shot 2017-07-31 at 11 24 28 am](https://user-images.githubusercontent.com/696595/28785050-34fc9b82-75e3-11e7-80cf-6b1d796918af.png)

**540px:**
![screen shot 2017-07-31 at 11 24 51 am](https://user-images.githubusercontent.com/696595/28785054-37955b0e-75e3-11e7-9240-b5372d0044fb.png)


#### Questions/Considerations
Are there any other elements on the article page that could be influenced by this change like the signup popup?