### PR TITLE
Updates to append ' | Shine' to all titles

### DIFF
--- a/config/hugo.config.base.toml
+++ b/config/hugo.config.base.toml
@@ -1,4 +1,4 @@
-title = "Get Advice | Shine"
+title = "Get Advice"
 contentdir = "hugo/content"
 dataDir = "hugo/data"
 layoutdir = "hugo/layouts"

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -13,7 +13,7 @@
 <!-- Site Title, Description and Favicon -->
 
 {{- with .Title | default .Site.Title }}
-  <title>{{ . }}</title>
+  <title>{{ . }} | Shine</title>
 {{- end }}
 
 

--- a/hugo/lib/createArticle.js
+++ b/hugo/lib/createArticle.js
@@ -9,7 +9,7 @@ module.exports = entry => {
   let { title, body, date, category, tags, slug, description } = content;
   let idxOfPubExMod = body.indexOf('<div class="pubexchange_module"'); // index of the pub exchange module in article body
   let type = 'article';
-  let cleanTitle = title.replace(/\"/g, '\\"');
+  let cleanTitle = title.replace(/\"/g, '\\"').trim();
   let cleanDescription = description.replace(/\"/g, '\\"').trim();
   let cleanBody = marked(body.slice(0, idxOfPubExMod)); // slice pubexchange off of article body
   let headerPhotoInfo = content.headerPhoto.fields;


### PR DESCRIPTION
#### What's this PR do?
Appends " | Shine" to all `title` tags. Removes it from the base site config, otherwise the homepage's title would be "Get Advice | Shine | Shine".

Also trimming whitespace from titles in the build script. Some scenarios were found while testing that resulted in `title` tags that looked like "Article Name    | Shine".

#### What are the relevant tickets?
Closes #92