### PR TITLE
add link to author for SEO

### DIFF
--- a/hugo/layouts/partials/article_modules/article_meta.html
+++ b/hugo/layouts/partials/article_modules/article_meta.html
@@ -1,5 +1,7 @@
 <!-- meta data attached to each article; needs to be customized for shine -->
+{{ $author := .Params.author }}
 <meta name="description" content="{{ .Params.description }}" />
+<link rel="author" href="{{ .Site.BaseURL }}author/{{ replaceRE " " "-" $author }}" />
 <meta property="author" content="{{ .Params.author }}" />
 <meta property="og:type" content="article" / >
 {{- partial "extra/meta_og.html" . }}


### PR DESCRIPTION
#### What's this PR do?
Adds link tags for author meta data. 

#### How was this tested? How should this be reviewed?
Tested using google chrome dev tools. 

#### What are the relevant tickets?
N/A

#### Questions / Considerations
An update for author meta information for article pages. After looking around at other blogs, and asking a few questions on reach flux it seems google ignores author meta data if not paired with a link to the author. 
