### PR TITLE
fix og:url meta tag format

### DIFF
--- a/hugo/layouts/partials/extra/meta_og.html
+++ b/hugo/layouts/partials/extra/meta_og.html
@@ -7,5 +7,5 @@
 {{- with .Params.image }}
 <meta property="og:image" content="https:{{ . }}?w=1200" />
 {{- end }}
-<meta property="og:url" content="{{ .Site.BaseURL }}{{ .URL }}" />
+<meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:site_name" content="Shine" />


### PR DESCRIPTION
#### What's this PR do?
Update meta link for og:url. 
![screen shot 2017-08-11 at 10 30 11 am](https://user-images.githubusercontent.com/15316174/29217583-3c7b0bbe-7e80-11e7-88c1-5b8fd4e4a72e.png)
Not sure if this just affects Facebook scraper but the fix will format this URL correctly. 

#### How was this tested? How should this be reviewed?
Tested on my local machine using chrome dev tools.

#### What are the relevant tickets?
N/A

#### Questions / Considerations
n/a