### PR TITLE
Fix to "undefined" canonical links

### DIFF
--- a/hugo/lib/createArticle.js
+++ b/hugo/lib/createArticle.js
@@ -57,7 +57,7 @@ module.exports = entry => {
   tags = ${JSON.stringify(tags)}
   author = "${name}"
   bio = ['${marked(bio)}']
-  canonicalLink = "${canonical}"
+  canonicalLink = "${canonical ? canonical : ''}"
   twitter = "${twitter ? twitter : ''}"
   instagram = "${instagram ? instagram : ''}"
   facebook = "${facebook ? facebook : ''}"


### PR DESCRIPTION
Previously, if a `canonical` value was not set, it would set the canonical link to `"undefined"`. Now as an empty string, the logic in **layouts/partials/includes.html** should just place the current URL in there.

Fixes #114 

### Verified in the deploy preview
View source: https://deploy-preview-115--shine-advice-production.netlify.com/articles/the-surprising-power-of-your-life-story/
```
<link rel="canonical" href="https://advice.shinetext.com/articles/the-surprising-power-of-your-life-story/" />
```
