### PR TITLE
Fixes robots.txt from getting written in production deploys

### DIFF
--- a/hugo/lib/build-content-url.sh
+++ b/hugo/lib/build-content-url.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 node getArticles.js $1
 node getUrl.js
+node writeRobotsTxt.js $1
 
 EXIT_STATUS=$?
 

--- a/hugo/lib/getUrl.js
+++ b/hugo/lib/getUrl.js
@@ -1,5 +1,5 @@
-const Promise = require("bluebird");
-const fs = Promise.promisifyAll(require("fs"));
+const Promise = require('bluebird');
+const fs = Promise.promisifyAll(require('fs'));
 
 /**
   * Get the current base for the hugo config and baseURL from Netlify ENV
@@ -12,18 +12,12 @@ const baseURL = process.env.BASE_URL
   : `baseURL = "\/"\n`;
 
 fs
-  .readFileAsync(__dirname + "/../../config/hugo.config.base.toml")
+  .readFileAsync(__dirname + '/../../config/hugo.config.base.toml')
   .then(function(configData) {
     hugoConfig = baseURL + configData.toString(); // concat baseURL and base config file
-  })
-  .then(function() {
+
     // Write hugo config file to config folder
-    fs.writeFile(__dirname + "/../../config/hugo.config.toml", hugoConfig);
-    // Write robots.txt file to static directory
-    let robotFileText = "User-agent: * \nDisallow: /";
-    if (baseURL !== "https://advice.shinetext.com/") {
-      fs.writeFile(__dirname + "/../static/robots.txt", robotFileText);
-    }
+    fs.writeFile(__dirname + '/../../config/hugo.config.toml', hugoConfig);
   })
   .catch(function(error) {
     console.error(error);

--- a/hugo/lib/writeRobotsTxt.js
+++ b/hugo/lib/writeRobotsTxt.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const fs = require('fs');
+
+/**
+ * Write robots.txt file for non-production builds.
+ */
+const env = process.argv.slice(2)[0];
+if (env !== '--production') {
+  console.log('Writing robots.txt file');
+  const content = `User-agent: *\nDisallow: /`;
+  fs.writeFile(`${__dirname}/../static/robots.txt`, content);
+}


### PR DESCRIPTION
### What was the problem?
The previous logic wrote the robots.txt file when this was true: `(baseURL !== "https://advice.shinetext.com/")`. But this always evaluated to true because baseURL essentially gets set to a string meant for the hugo.config.base.toml file. `"baseUrl = ${process.env.BASE_URL || "/"}"`

### How was this tested?
Local testing running npm run build-script-staging and npm run build-script-production and verified the robots.txt file was not written for production builds.