### PR TITLE
Another attempt at fixing the robots.txt on production

### DIFF
--- a/hugo/content/page/about.md
+++ b/hugo/content/page/about.md
@@ -1,6 +1,0 @@
----
-title: About
-description: Time to Get Your Shine On?!
-menu: main
-weight: -170
----

--- a/hugo/lib/build-content-url.sh
+++ b/hugo/lib/build-content-url.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 
 node getArticles.js $1
 node getUrl.js
+
+# Clear any existing robots.txt
+rm -f ../static/robots.txt
 node writeRobotsTxt.js $1
 
 EXIT_STATUS=$?

--- a/hugo/lib/writeRobotsTxt.js
+++ b/hugo/lib/writeRobotsTxt.js
@@ -6,8 +6,14 @@ const fs = require('fs');
  * Write robots.txt file for non-production builds.
  */
 const env = process.argv.slice(2)[0];
-if (env !== '--production') {
-  console.log('Writing robots.txt file');
+if (env === '--production') {
+  // Allow robots complete access
+  const content = `User-agent: *\nDisallow:`;
+  console.log(`Writing robots.txt file:\t${content}`);
+  fs.writeFile(`${__dirname}/../static/robots.txt`, content);
+} else {
+  // Disallow robot access
   const content = `User-agent: *\nDisallow: /`;
+  console.log(`Writing robots.txt file:\t${content}`);
   fs.writeFile(`${__dirname}/../static/robots.txt`, content);
 }


### PR DESCRIPTION
- Removing any existing robots.txt file from the static folder during build and deploy
- Writing a new robots.txt file for production that allows robots all access
- And unrelated, just removing the about page since it's not being used, but is still a page that gets built and deployed