### PR TITLE
Add netlify redirects file to build folder

### DIFF
--- a/hugo/static/_redirects
+++ b/hugo/static/_redirects
@@ -1,0 +1,3 @@
+# Redirects from what the browser requests to what we serve
+
+/articles/how-to-make-progress-and-feel-like-youre-making-progress/   /articles/how-a-dash-of-mindfulness-can-help-you-get-more-done/   301


### PR DESCRIPTION
#### What's this PR do?
1. Redirects links to removed articles to a similar article.
2. Adds static `_redirect` file to public folder used by netlify. 

#### How was this tested? How should this be reviewed?
Tested using the netlify staging link.

#### What are the relevant tickets?
`https://trello.com/c/GSSY0pxC/34-create-redirect-for-a-deleted-page`

#### Questions / Considerations

