### PR TITLE
Fix overextend width of featured article category span

### DIFF
--- a/src/less/blog-v2/includes/latest-articles.less
+++ b/src/less/blog-v2/includes/latest-articles.less
@@ -31,6 +31,7 @@
     a:hover {
       text-decoration: none;
     }
+    width: 95%;
   }
   .-content {
     width: 95%;


### PR DESCRIPTION
#### What's this PR do?
Fix overextended with of category banners 
Before
![screen shot 2018-03-27 at 12 05 27 pm](https://user-images.githubusercontent.com/15316174/37979725-54de9956-31b7-11e8-9348-72ce18e68cdd.png)
After
![screen shot 2018-03-27 at 12 05 36 pm](https://user-images.githubusercontent.com/15316174/37979731-56d6dbba-31b7-11e8-85bf-9fcd6d3756b4.png)

#### How was this tested? How should this be reviewed?
Tested on safari/c
hrome & brave 

#### What are the relevant tickets?
N/A. Flagged by content team

#### Questions / Considerations
