### PR TITLE
Fix homepage category span. 

### DIFF
--- a/hugo/static/_redirects
+++ b/hugo/static/_redirects
@@ -1,4 +1,4 @@
 # Redirects from what the browser requests to what we serve
 
 /articles/how-to-make-progress-and-feel-like-youre-making-progress/   /articles/how-a-dash-of-mindfulness-can-help-you-get-more-done/   301
-articles/niksen-is-the-danish-solution-for-a-guilt-free-break/   articles/niksen-is-the-dutch-solution-for-a-guilt-free-break/   301
+/articles/niksen-is-the-danish-solution-for-a-guilt-free-break/   /articles/niksen-is-the-dutch-solution-for-a-guilt-free-break/   301


### PR DESCRIPTION
#### What's this PR do?
Prevent the overextending of the black background of the category span on the blog homepage.