### PR TITLE
Add typeform script to footer

### DIFF
--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -21,6 +21,8 @@
   <script type="text/javascript" src="{{ .Site.BaseURL }}scripts/slideup.js"></script>
   <script src='{{ $.Site.Data.path.manifest.mainjs | relURL }}'></script>
   <script src='{{ "scripts/main.js" | relURL }}'></script>
+  <script src='{{ "scripts/typeform.js" | relURL }}'></script>
+
 </footer>
 
 {{- partial "footer_custom.html" . }}

--- a/hugo/static/scripts/typeform.js
+++ b/hugo/static/scripts/typeform.js
@@ -1,0 +1,19 @@
+(function() {
+  var qs,
+    js,
+    q,
+    s,
+    d = document,
+    gi = d.getElementById,
+    ce = d.createElement,
+    gt = d.getElementsByTagName,
+    id = 'typef_orm',
+    b = 'https://embed.typeform.com/';
+  if (!gi.call(d, id)) {
+    js = ce.call(d, 'script');
+    js.id = id;
+    js.src = b + 'embed.js';
+    q = gt.call(d, 'script')[0];
+    q.parentNode.insertBefore(js, q);
+  }
+})();


### PR DESCRIPTION
#### What's this PR do?
Gives content creators the ability to add typeform polls into articles. 

#### Questions / Considerations
Before embedding a typeform poll editors must first remove script tag.

Origial won't work
```
<div class="typeform-widget" data-url="https://shine32.typeform.com/to/IK4kxM" style="width: 100%; height: 500px;"></div> 

<script> (function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm", b="https://embed.typeform.com/"; if(!gi.call(d,id)) { js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })() </script> 

<div style="font-family: Sans-Serif;font-size: 12px;color: #999;opacity: 0.5; padding-top: 5px;"> powered by <a href="https://admin.typeform.com/signup?utm_campaign=IK4kxM&utm_source=typeform.com-9311471-Pro&utm_medium=typeform&utm_content=typeform-embedded-poweredbytypeform&utm_term=EN" style="color: #999" target="_blank">Typeform</a> </div>
```

Will work minus script tag
```
<div class="typeform-widget" data-url="https://shine32.typeform.com/to/IK4kxM" style="width: 100%; height: 500px;"></div> 

<div style="font-family: Sans-Serif;font-size: 12px;color: #999;opacity: 0.5; padding-top: 5px;"> powered by <a href="https://admin.typeform.com/signup?utm_campaign=IK4kxM&utm_source=typeform.com-9311471-Pro&utm_medium=typeform&utm_content=typeform-embedded-poweredbytypeform&utm_term=EN" style="color: #999" target="_blank">Typeform</a> </div>
```


![screen shot 2018-05-01 at 12 53 36 pm](https://user-images.githubusercontent.com/15316174/39482915-bec9037c-4d3e-11e8-8b67-0a6b9ec17b4b.png)

![screen shot 2018-05-01 at 12 54 46 pm](https://user-images.githubusercontent.com/15316174/39482956-e3e6568c-4d3e-11e8-8770-67845f26539d.png)
