### PR TITLE
Replace old sumo script tag. Move script tag to body of html.

### DIFF
--- a/hugo/layouts/_default/baseof.html
+++ b/hugo/layouts/_default/baseof.html
@@ -3,6 +3,7 @@
 {{ partial "head.html" . }}
 <body>
   {{- partial "extra/gtm_body.html" . }}
+  {{- partial "extra/sumo.html" . }}
   {{- partial "nav.html" . }}
   {{ block "header" . }}
     {{- partial "header.html" . }}

--- a/hugo/layouts/partials/extra/sumo.html
+++ b/hugo/layouts/partials/extra/sumo.html
@@ -1,0 +1,1 @@
+<script async>(function(s,u,m,o,j,v){j=u.createElement(m);v=u.getElementsByTagName(m)[0];j.async=1;j.src=o;j.dataset.sumoSiteId='a67d2a27d703a5b063170cf719099ec653218686c511e6866a2c38d8dd1f52a2';v.parentNode.insertBefore(j,v)})(window,document,'script','//load.sumo.com/');</script>

--- a/hugo/layouts/partials/homepage_modules/homepage_meta.html
+++ b/hugo/layouts/partials/homepage_modules/homepage_meta.html
@@ -1,6 +1,6 @@
 <meta name="description" content="{{ .Site.Params.description }}" />
-<meta property="og:url" content="http://advice.shinetext.com/" />
+<meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:title" content="Get Advice | Shine" />
-<meta property="og:description" content="Career and life advice from real people. Get daily fulfillment and read up on how to live your best life." />
+<meta property="og:description" content="{{ .Site.Params.description }}" />
 <meta property="og:site_name" content="Shine" />
 <meta property="og:image" content="https://images.contentful.com/awpxl2koull4/FFhnW3pbga4qmCOM24kmc/8c718dac9a5357db86c55b637461f4f3/Shine-logo-web.png" />

--- a/hugo/layouts/partials/includes.html
+++ b/hugo/layouts/partials/includes.html
@@ -7,7 +7,6 @@
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css?family=Poppins:400,700" rel="stylesheet">
-<script src="//load.sumome.com/" data-sumo-site-id="a67d2a27d703a5b063170cf719099ec653218686c511e6866a2c38d8dd1f52a2" async="async"></script>
 {{ if .Params.canonicalLink }}
   <link rel="canonical" href="{{ .Params.canonicalLink }}" />
 {{ else }}


### PR DESCRIPTION
#### What's this PR do?

- Update meta tag on homepage from 'http' to 'https'
- Replace old sumo install script tag with new version
- Move script tag from header to body of html(Recommended by sumo engineer)

#### How was this tested? How should this be reviewed?
Review using chrome inspector and sharing an article using sumo share bar. 

#### What are the relevant tickets?
Bug raised in slack. Article share counts not updating after sharing on twitter.

Example:  `https://advice.shinetext.com/articles/how-to-deal-when-you-just-dont-feel-like-enough/`
