### PR TITLE
Decreases the query limit for article pulls to 250

### DIFF
--- a/hugo/lib/getArticles.js
+++ b/hugo/lib/getArticles.js
@@ -45,7 +45,7 @@ Promise.coroutine(function*() {
 
     let query = {
       content_type: 'article',
-      limit: 1000, // default is 100. max is 1000
+      limit: 250, // default is 100. max is 1000
       skip: 0,
     };
 


### PR DESCRIPTION
#### What's this PR do?
We just started running into an error at ~633 articles with the Contentful API: "Response size too big, was: 7354796b. Maximum allowed response size: 7340032b." So by decreasing the number of articles we receive per query, we should be able to safely avoid this error.

#### How was this tested? How should this be reviewed?
Tested locally pulling down content for production. Confirmed that the article that we're currently unable to pull and publish got pulled down to my local setup.

#### What are the relevant tickets?
https://shinetext.atlassian.net/browse/SHI-839
