### PR TITLE
Adds custom RSS template

### DIFF
--- a/config/hugo.config.base.toml
+++ b/config/hugo.config.base.toml
@@ -11,6 +11,7 @@ theme =  ""
 googleAnalytics = "UA-68971267-1"
 paginate = 9
 enableRobotsTXT = true
+languageCode = "en"
 
 [params]
   description = "Career and life advice from real people. Get daily fulfillment and read up on how to live your best life."

--- a/hugo/layouts/rss.xml
+++ b/hugo/layouts/rss.xml
@@ -1,0 +1,29 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ .Site.Title }} | Shine</title>
+    <link>{{ .Permalink }}</link>
+    <description>{{ .Site.Params.Description }}</description>
+    <generator>Hugo -- gohugo.io</generator>
+    {{ with .Site.LanguageCode }}<language>{{.}}</language>{{end}}
+    {{ with .Site.Author.email }}<managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}
+    {{ with .Site.Author.email }}<webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}
+    {{ with .Site.Copyright }}<copyright>{{.}}</copyright>{{end}}
+    {{ if not .Date.IsZero }}<lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{ with .OutputFormats.Get "RSS" }}
+        {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{ end }}
+    {{ range .Pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      <dc:creator>{{ .Params.author }}</dc:creator>
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Summary | html }}</description>
+      <enclosure>{{ .Params.Image }}</enclosure>
+    </item>
+    {{ end }}
+  </channel>
+</rss>


### PR DESCRIPTION
#### What's this PR do?
This is based off the default template: https://gohugo.io/templates/rss/#the-embedded-rss-xml

I primarily wanted to add a couple fields as needed for Flipboard: https://about.flipboard.com/rss-spec/

So the only two new ones here are really:
- `dc:creator`
- `enclosure`

Just a note too that apparently the file needs to be named **rss.xml**. I tried a couple of the other combinations, but my changes never showed up in the generated feed if I did.

#### How was this tested? How should this be reviewed?
Tested locally with the RSS feed generated locally.

I'll want to double check with the deploy previews to make sure those show the new fields as well.

#### What are the relevant tickets?
https://shinetext.atlassian.net/browse/SHI-1199
