### PR TITLE
Fixes enclosure RSS field

### DIFF
--- a/hugo/layouts/rss.xml
+++ b/hugo/layouts/rss.xml
@@ -1,4 +1,3 @@
-{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ .Site.Title }} | Shine</title>
@@ -11,7 +10,7 @@
     {{ with .Site.Copyright }}<copyright>{{.}}</copyright>{{end}}
     {{ if not .Date.IsZero }}<lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
-        {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
     {{ range .Pages }}
     <item>
@@ -22,7 +21,7 @@
       <dc:creator>{{ .Params.author }}</dc:creator>
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
-      <enclosure>{{ .Params.Image }}</enclosure>
+      <enclosure url="https:{{ .Params.Image }}" length="{{ .Params.ImageSize }}" type="{{ .Params.ImageContentType }}" />
     </item>
     {{ end }}
   </channel>

--- a/hugo/lib/createArticle.js
+++ b/hugo/lib/createArticle.js
@@ -52,6 +52,8 @@ module.exports = entry => {
   slug = "${slug}"
   categories = ["${category}"]
   image = "${headerPhotoInfo.file.url}"
+  imageContentType = "${headerPhotoInfo.file.contentType}"
+  imageSize = "${headerPhotoInfo.file.details.size}"
   authorImage = "${authorImageInfo.file.url}"
   featured = false
   tags = ${JSON.stringify(tags)}


### PR DESCRIPTION
### What's this PR do?
Fixes the `enclosure` field in our RSS feed. I was totally wrong about how that field was [suppose to work](https://www.w3schools.com/xml/rss_tag_enclosure.asp).

Since it also needs the media type and size in bytes, we're getting that additional info from the Contentful API and passing it along.

Also removing the xml version 1.0 line because it was getting duplicated. There must a process somewhere else that's adding that line to the top of the file too.

### How was this tested? How should this be reviewed?
Locally tested. And deploy preview looks good too: https://deploy-preview-167--shine-advice-staging.netlify.com/index.xml

### What are the relevant tickets?
https://shinetext.atlassian.net/browse/SHI-1199
