### PR TITLE
Adds json output for a read-only API for articles

### DIFF
--- a/config/hugo.config.base.toml
+++ b/config/hugo.config.base.toml
@@ -58,3 +58,6 @@ defaultContentLanguage = "en"
     lang = "en"
     languageName = "English"
     weight = 1
+
+[outputs]
+  page = ["html", "json"]

--- a/hugo/layouts/_default/single.json.json
+++ b/hugo/layouts/_default/single.json.json
@@ -1,0 +1,19 @@
+{
+  "author": {
+    "name": "{{ .Params.Author }}",
+    "bio": {{ .Params.bio | jsonify }},
+    "image": "{{ .Params.authorImage }}"
+  },
+  "image": {
+    "contentType": "{{ .Params.imageContentType }}",
+    "size": "{{ .Params.imageSize }}",
+    "url": "{{ .Params.image }}"
+  },
+  "categories": {{ .Params.categories | jsonify }},
+  "content": {{ .Content | jsonify }},
+  "date": "{{ .Params.date }}",
+  "description": {{ .Description | jsonify }},
+  "slug": "{{ .Params.slug }}",
+  "title": "{{ .Title }}",
+  "tags": {{ .Params.tags | jsonify }}
+}


### PR DESCRIPTION
#### What's this PR do?
Adds the configuration and template for creating json files for each article. They'll output at /articles/<slug>/index.json.

Hugo's doing pretty much all of the work during the same build step it's creating the html pages.

#### How was this tested?
Local testing. The .json files get created/refreshed when you run `npm run hugo-server`.

#### Context
This is for a potential future of bringing a more native article experience into the pap.
