### PR TITLE
Adds a stylesheet for printing

### DIFF
--- a/src/less/blog-v2/print.less
+++ b/src/less/blog-v2/print.less
@@ -27,12 +27,27 @@
   }
 
   #shine-article {
-    #article-body blockquote {
-      border-right: 0;
+    #article-body {
+      font-size: 14px;
 
-      /* Hides the yellow triangle in blockquotes */
-      p:before {
-        content: none;
+      blockquote {
+        border-right: 0;
+        padding: 20px;
+
+        p {
+          font-size: 18px;
+        }
+
+        /* Hides the yellow triangle in blockquotes */
+        p:before {
+          content: none;
+        }
+      }
+
+      .dropcap {
+        font-size: 40px;
+        padding-top: 0;
+        padding-right: 4px;
       }
     }
 

--- a/src/less/blog-v2/print.less
+++ b/src/less/blog-v2/print.less
@@ -1,0 +1,57 @@
+@media print {
+  /* Hide URLs from all the `a` tags */
+  a[href]:after {
+    content: none !important;
+  }
+
+  #footer {
+    display: none;
+  }
+
+  .category-bar {
+    display: none;
+  }
+
+  /* Make sure this is showing so that printed pages still get Shine branding */
+  .navbar {
+    display: block !important;
+  }
+
+  /* Hide Sumo sidebar */
+  .sumome-share-client-wrapper {
+    display: none !important;
+  }
+
+  #shine-article {
+    #article-body blockquote {
+      border-right: 0;
+
+      /* Hides the yellow triangle in blockquotes */
+      p:before {
+        content: none;
+      }
+    }
+
+    .container-header {
+      display: none;
+    }
+
+    .join-bar-article {
+      display: none;
+    }
+
+    .main-article-content {
+      margin-top: 0;
+    }
+
+    .pre-article-content {
+      .social-container {
+        display: none;
+      }
+    }
+
+    .pubexchange_module {
+      display: none;
+    }
+  }
+}

--- a/src/less/blog-v2/print.less
+++ b/src/less/blog-v2/print.less
@@ -8,6 +8,10 @@
     display: none;
   }
 
+  #mobile-menu {
+    display: none;
+  }
+
   .category-bar {
     display: none;
   }

--- a/src/less/importer.less
+++ b/src/less/importer.less
@@ -8,9 +8,10 @@
 @import 'blog-v2/includes/shine-squad-cards.less';
 @import 'blog-v2/includes/footer.less';
 @import 'blog-v2/includes/navbar.less';
-@import "blog-v2/articles.less";
-@import "blog-v2/includes/latest-articles.less";
-@import "blog-v2/includes/popular-articles.less";
-@import "blog-v2/includes/conversion-popup.less";
+@import 'blog-v2/articles.less';
+@import 'blog-v2/includes/latest-articles.less';
+@import 'blog-v2/includes/popular-articles.less';
+@import 'blog-v2/includes/conversion-popup.less';
 
 @import 'blog-v2/main.less';
+@import 'blog-v2/print.less';


### PR DESCRIPTION
#### What's this PR do?
Fixes the page styles to be _a lot_ more printer friendly.

The `@media print` query only gets applied to the page when it's getting made to print.

#### How was this tested?
So I just learned this, you can emulate what the printer will see/print in Chrome.

**DevTools > open the menu icon > More tools > Rendering > Emulate CSS media > print**

Before:
<img src="https://user-images.githubusercontent.com/696595/69441059-f0961d00-0d17-11ea-963b-b837e0df3a54.png" width="300">

After:
<img src="https://user-images.githubusercontent.com/696595/69441070-f429a400-0d17-11ea-84dc-3001e4291448.png" width="300">

#### What are the relevant tickets?
https://shinetext.atlassian.net/browse/SHI-1824