### PR TITLE
Adds support for different SEO and article titles

### DIFF
--- a/hugo/layouts/partials/extra/meta_og.html
+++ b/hugo/layouts/partials/extra/meta_og.html
@@ -1,6 +1,10 @@
-{{- with .Title | default .Site.Title }}
-<meta property="og:title" content="{{ . }}" />
-{{- end }}
+{{ if .Params.metaTitle }}
+<meta property="og:title" content="{{- .Params.metaTitle }}" />
+{{ else if .Title }}
+<meta property="og:title" content="{{- .Title }}" />
+{{ else }}
+<meta property="og:title" content="{{- .Site.Title }}" />
+{{ end }}
 {{- with .Params.description }}
 <meta property="og:description" content="{{ . }}" />
 {{- end }}

--- a/hugo/layouts/partials/extra/meta_twitter.html
+++ b/hugo/layouts/partials/extra/meta_twitter.html
@@ -1,6 +1,10 @@
-{{- with .Title | default .Site.Title }}
-<meta property="twitter:title" content="{{ . }}" />
-{{- end }}
+{{ if .Params.metaTitle }}
+<meta property="twitter:title" content="{{- .Params.metaTitle }}" />
+{{ else if .Title }}
+<meta property="twitter:title" content="{{- .Title }}" />
+{{ else }}
+<meta property="twitter:title" content="{{- .Site.Title }}" />
+{{ end }}
 {{- with .Params.description }}
 <meta property="twitter:description" content="{{ . }}" />
 {{- end }}

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -13,7 +13,7 @@
   <!-- Site Title, Description and Favicon -->
 
   {{ if .Params.metaTitle }}
-  <title>{{- .Params.metaTitle }}</title>
+  <title>{{- .Params.metaTitle }} | Shine</title>
   {{ else if .Title }}
   <title>{{- .Title}} | Shine</title>
   {{ else }}

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -12,9 +12,13 @@
   {{ end }}
   <!-- Site Title, Description and Favicon -->
 
-  {{- with .Title | default .Site.Title }}
-  <title>{{ . }} | Shine</title>
-  {{- end }}
+  {{ if .Params.metaTitle }}
+  <title>{{- .Params.metaTitle }}</title>
+  {{ else if .Title }}
+  <title>{{- .Title}} | Shine</title>
+  {{ else }}
+  <title>{{- .Site.Title }} | Shine</title>
+  {{ end }}
 
   {{ if and .Title .Params.author .Params.image }}
   <script type="application/ld+json">

--- a/hugo/lib/createArticle.js
+++ b/hugo/lib/createArticle.js
@@ -13,6 +13,7 @@ module.exports = entry => {
     category,
     tags,
     slug,
+    metaTitle,
     description,
     canonical,
   } = content;
@@ -48,6 +49,7 @@ module.exports = entry => {
   const templateData = `+++
   date = "${moment(date).format()}"
   title = "${cleanTitle}"
+  metaTitle = "${metaTitle ? metaTitle : ''}"
   description = "${cleanDescription}"
   slug = "${slug}"
   categories = ["${category}"]


### PR DESCRIPTION
#### What's this PR do?
If a `metaTitle` is provided, we'll use that as the copy for:
- `<title>`
- `og:title` meta tag
- `twitter:title` meta tag

This won't affect the article title that's rendered in the `h1` tag.

I've already added `metaTitle` as an optional field in the Article content model on Contentful.

#### How was this tested?
Tested an article with `metaTitle` set and confirmed meta tags were different and article title remained the same. And tested page where no `metaTitle` was set and confirmed all tags and article title remained unchanged.