### PR TITLE
Adds virusanxiety links to footer and header

### DIFF
--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -9,6 +9,7 @@
     </div>
     <div class="page-links">
       <a href="https://join.shinetext.com">Join Shine</a>
+      <a href="https://virusanxiety.com">Coronavirus Anxiety</a>
       <a href="https://premium.shinetext.com/quiz/start?utm_source=Shine&utm_medium=Blog&utm_campaign=Footer">Self-Care Style Quiz</a>
       <a href="/">Get Advice</a>
       <a href="https://shop.shinetext.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Footer">Shine Shop</a>

--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -9,10 +9,9 @@
     </div>
     <div class="page-links">
       <a href="https://join.shinetext.com">Join Shine</a>
-      <a href="https://virusanxiety.com">Coronavirus Anxiety</a>
+      <a href="https://virusanxiety.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Footer">Coronavirus Anxiety</a>
       <a href="https://premium.shinetext.com/quiz/start?utm_source=Shine&utm_medium=Blog&utm_campaign=Footer">Self-Care Style Quiz</a>
       <a href="/">Get Advice</a>
-      <a href="https://shop.shinetext.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Footer">Shine Shop</a>
       <a href="https://www.shinetext.com/gift">Send a Gift</a>
       <a href="https://www.shinetext.com/squad">The Squad</a>
       <a href="https://www.shinetext.com/jobs">Careers</a>

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -34,10 +34,12 @@ class Header extends Component {
 
           <div className="navbar-links-container">
             <div className="navbar-links">
-              <a href="https://premium.shinetext.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">Shine Premium</a>
+              <a href="https://premium.shinetext.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+                Shine Premium
+              </a>
             </div>
             <div className="navbar-links">
-              <a href="https://premium.shinetext.com/quiz/start?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">Self-Care Style Quiz</a>
+              <a href="https://virusanxiety.com">Coronavirus Anxiety</a>
             </div>
             <div className="navbar-links">
               <a className="nav-open" href="/">
@@ -64,10 +66,12 @@ class Header extends Component {
           />
           <ul>
             <li>
-              <a href="https://premium.shinetext.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">Shine Premium</a>
+              <a href="https://premium.shinetext.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+                Shine Premium
+              </a>
             </li>
             <li>
-              <a href="https://premium.shinetext.com/quiz/start?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">Self-Care Style Quiz</a>
+              <a href="https://virusanxiety.com">Coronavirus Anxiety</a>
             </li>
             <li>
               <a href="/">Get Advice </a>

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -39,13 +39,13 @@ class Header extends Component {
               </a>
             </div>
             <div className="navbar-links">
-              <a href="https://virusanxiety.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
-                Coronavirus Anxiety
+              <a href="https://premium.shinetext.com/quiz/start?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+                Self-Care Style Quiz
               </a>
             </div>
             <div className="navbar-links">
-              <a href="https://premium.shinetext.com/quiz/start?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
-                Self-Care Style Quiz
+              <a href="https://virusanxiety.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+                Coronavirus Anxiety
               </a>
             </div>
             <div className="navbar-links">
@@ -78,7 +78,14 @@ class Header extends Component {
               </a>
             </li>
             <li>
-              <a href="https://virusanxiety.com">Coronavirus Anxiety</a>
+              <a href="https://premium.shinetext.com/quiz/start?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+                Self-Care Style Quiz
+              </a>
+            </li>
+            <li>
+              <a href="https://virusanxiety.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+                Coronavirus Anxiety
+              </a>
             </li>
             <li>
               <a href="/">Get Advice </a>

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -39,7 +39,14 @@ class Header extends Component {
               </a>
             </div>
             <div className="navbar-links">
-              <a href="https://virusanxiety.com">Coronavirus Anxiety</a>
+              <a href="https://virusanxiety.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+                Coronavirus Anxiety
+              </a>
+            </div>
+            <div className="navbar-links">
+              <a href="https://premium.shinetext.com/quiz/start?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+                Self-Care Style Quiz
+              </a>
             </div>
             <div className="navbar-links">
               <a className="nav-open" href="/">

--- a/src/less/blog-v2/includes/navbar.less
+++ b/src/less/blog-v2/includes/navbar.less
@@ -79,7 +79,7 @@
       }
     }
 
-    @media (max-width: 880px) {
+    @media (max-width: 960px) {
       display: none;
     }
   }
@@ -96,7 +96,7 @@
   right: 0;
   top: 50%;
 
-  @media (max-width: 880px) {
+  @media (max-width: 960px) {
     display: inline-block;
   }
 }


### PR DESCRIPTION
#### What's this PR do?
Links to virusanxiety.com added to the header and footer.

Worth noting that in the header menu, I'm replacing what used to be the Self-Care Style Quiz. @angelahum that's ok, right? It's still available in the footer should we need it, but it seemed like we had deprioritized using that.

This shouldn't be pushed to `releases` until the virusanxiety.com site is published.

#### How was this tested?
Local testing. Should be able to use the deploy previews to check it out too.