### PR TITLE
Updates to nav and footer

### DIFF
--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -8,14 +8,15 @@
       <a class="-icon-pinterest" href="https://www.pinterest.com/ShineText" target="_blank"></a>
     </div>
     <div class="page-links">
-      <a href="https://join.shinetext.com">Join Shine</a>
-      <a href="https://virusanxiety.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Footer">Coronavirus Anxiety</a>
-      <a href="https://premium.shinetext.com/quiz/start?utm_source=Shine&utm_medium=Blog&utm_campaign=Footer">Self-Care Style Quiz</a>
-      <a href="/">Get Advice</a>
-      <a href="https://www.shinetext.com/gift">Send a Gift</a>
+      <a href="https://join.shinetext.com/about">About</a>
       <a href="https://www.shinetext.com/squad">The Squad</a>
       <a href="https://www.shinetext.com/jobs">Careers</a>
+      <a href="https://join.shinetext.com/shine-at-work">Shine at Work</a>
+      <a href="/">Get Advice</a>
+      <a href="https://virusanxiety.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Footer">Coronavirus Anxiety</a>
+      <a href="https://www.shinetext.com/gift">Send a Gift</a>
       <a href="https://shinetext.zendesk.com/hc/en-us">FAQ</a>
+      <a href="https://shinetext.zendesk.com/hc/en-us/categories/360002145271-Contact-Us">Contact</a>
       <a href="https://www.shinetext.com/privacy-policy">Privacy Policy</a>
       <a href="https://www.shinetext.com/terms-of-service">Terms of Service</a>
     </div>

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -25,7 +25,7 @@ class Header extends Component {
     return (
       <header>
         <div className="navbar">
-          <a href="https://advice.shinetext.com">
+          <a href="https://www.shinetext.com">
             <img
               className="shine-logo"
               src="https://images.ctfassets.net/awpxl2koull4/6Ge2cCqfKg0IM8CIsOMiq6/bc0dee5dd91c1b37a155c220e95893d4/shine-logo-nav-122018.png?w=100"
@@ -34,28 +34,21 @@ class Header extends Component {
 
           <div className="navbar-links-container">
             <div className="navbar-links">
-              <a href="https://premium.shinetext.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
-                Shine Premium
+              <a href="https://join.shinetext.com/about?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+                About
               </a>
             </div>
             <div className="navbar-links">
-              <a href="https://premium.shinetext.com/quiz/start?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
-                Self-Care Style Quiz
+              <a href="/">Advice</a>
+            </div>
+            <div className="navbar-links">
+              <a href="https://join.shinetext.com/shine-at-work?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+                Shine at Work
               </a>
             </div>
             <div className="navbar-links">
-              <a href="https://virusanxiety.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
-                Coronavirus Anxiety
-              </a>
-            </div>
-            <div className="navbar-links">
-              <a className="nav-open" href="/">
-                Get Advice
-              </a>
-            </div>
-            <div className="navbar-links">
-              <a href="https://www.shinetext.com/squad/?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
-                The Squad
+              <a href="https://join.shinetext.com/get-started?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+                Get Started
               </a>
             </div>
           </div>
@@ -73,22 +66,13 @@ class Header extends Component {
           />
           <ul>
             <li>
-              <a href="https://premium.shinetext.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
-                Shine Premium
+              <a href="https://join.shinetext.com/about?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+                About
               </a>
             </li>
+
             <li>
-              <a href="https://premium.shinetext.com/quiz/start?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
-                Self-Care Style Quiz
-              </a>
-            </li>
-            <li>
-              <a href="https://virusanxiety.com?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
-                Coronavirus Anxiety
-              </a>
-            </li>
-            <li>
-              <a href="/">Get Advice </a>
+              <a href="/">Advice </a>
               <i
                 className="fa fa-plus plus-icon"
                 onClick={() => {
@@ -111,8 +95,13 @@ class Header extends Component {
               </ul>
             </li>
             <li>
-              <a href="https://www.shinetext.com/squad?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
-                The Squad
+              <a href="https://join.shinetext.com/shine-at-work?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+                Shine at Work
+              </a>
+            </li>
+            <li>
+              <a href="https://join.shinetext.com/get-started?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+                Get Started
               </a>
             </li>
           </ul>


### PR DESCRIPTION
#### What's this PR do?
Updates content and behavior of the top nav and the footer. I don't think it's worth the effort right now to try to style the two sections to match glow-web. But we can at least get the content to more closely match.

Here's what the top nav will now look like.
- On desktop:
  <img width="500" alt="Screen Shot 2020-07-29 at 9 40 42 PM" src="https://user-images.githubusercontent.com/696595/88871590-45aefa80-d1e6-11ea-96b8-9ad7e1e8a7bb.png">

- On mobile:
  <img width="280" alt="Screen Shot 2020-07-29 at 9 41 23 PM" src="https://user-images.githubusercontent.com/696595/88871587-45aefa80-d1e6-11ea-972c-654ec527e7ba.png">


#### How was this tested?
Homepage on my localhost and trying out all the updated links.

#### What are the relevant tickets?
https://shinetext.atlassian.net/browse/SHI-2157