### PR TITLE
Update hardcoded shinetext links to theshineapp.com

### DIFF
--- a/hugo/layouts/partials/article_modules/article_post_article.html
+++ b/hugo/layouts/partials/article_modules/article_post_article.html
@@ -1,5 +1,5 @@
 <div class="affiliate-disclosure">
-    <p><em>Shine is supported by members like you. When you buy through links on our site, we may earn an affiliate commission. See our <a href="https://www.shinetext.com/privacy-policy">affiliate disclosure</a> for more info.</em>
+    <p><em>Shine is supported by members like you. When you buy through links on our site, we may earn an affiliate commission. See our <a href="https://www.theshineapp.com/privacy-policy">affiliate disclosure</a> for more info.</em>
   </p>
   </div>
 <div class="social-container">

--- a/hugo/layouts/partials/extra/join_bar.html
+++ b/hugo/layouts/partials/extra/join_bar.html
@@ -1,6 +1,6 @@
 <div class="join-bar">
     <div class="join-message">Meditate, connect and reflect with Shine</div>
-    <a href="https://join.shinetext.com/?utm_source=Shine&utm_medium=Blog&utm_campaign=Join_Bar_Homepage">
+    <a href="https://www.theshineapp.com/?utm_source=Shine&utm_medium=Blog&utm_campaign=Join_Bar_Homepage">
       <div class="signup-button">Learn More</div>
     </a>
 </div>

--- a/hugo/layouts/partials/extra/join_bar_article.html
+++ b/hugo/layouts/partials/extra/join_bar_article.html
@@ -3,7 +3,7 @@
     <img src="https://images.ctfassets.net/awpxl2koull4/6Uev3DXZslI1qBDgzCwKZG/cceab49f9431dcb68441dcef39d5d619/community-phone-small.png
     "/>
     <div class="join-message-description">Get real-time advice, lift up others, and feel connected to kind, motivated people across the world.</div>
-    <a href="https://premium.shinetext.com/promo/shine-squad-40?utm_source=Shine&utm_medium=Article&utm_campaign=Join_Bar">
+    <a href="https://www.theshineapp.com/promo/shine-squad-40?utm_source=Shine&utm_medium=Article&utm_campaign=Join_Bar">
       <div class="signup-button-article">Join and Get 40% Off</div>
     </a>
 </div>

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -38,7 +38,7 @@
         "url": "{{ .Site.Params.shine_logo }}"
       },
       "name": "Shine",
-      "url": "https://www.shinetext.com"
+      "url": "https://www.theshineapp.com"
     },
     "image": [
       "https:{{ .Params.image }}?fit=fill&w=960&h=960",

--- a/hugo/layouts/partials/homepage_modules/shine_squad_cards.html
+++ b/hugo/layouts/partials/homepage_modules/shine_squad_cards.html
@@ -1,15 +1,15 @@
 <div class="shine-squad-cards">
-  <a href="https://advice.shinetext.com/articles/4-ways-to-combat-impostor-syndrome/" class="-card">
+  <a href="https://advice.theshineapp.com/articles/4-ways-to-combat-impostor-syndrome/" class="-card">
     <img class="-image" src="https://images.contentful.com/awpxl2koull4/zbBgyVSG2Wi6SSi0YQ6SK/cbd04950cd72220410abe3218dd4b5e9/Lisa_Rogoff.jpg?fit=thumb&w=100&h=100">
     <p class="-testimonial">"Let go of perfect and just do it"</p>
     <p class="-name">Lisa Rogoff</p>
   </a>
-  <a href="https://advice.shinetext.com/articles/shine-squad-feature-ninas-4-tips-to-slow-down-and-enjoy-life/" class="-card">
+  <a href="https://advice.theshineapp.com/articles/shine-squad-feature-ninas-4-tips-to-slow-down-and-enjoy-life/" class="-card">
     <img class="-image" src="https://images.contentful.com/awpxl2koull4/5dE8liGHAcUAQwOWAsEyYQ/08ffad03cfec8a6c7a9a217232a72088/Nina.jpg?fit=thumb&w=100&h=100">
     <p class="-testimonial">"Don’t rush through life and miss out on opportunities for growth"</p>
     <p class="-name">Nina Hosmane</p>
   </a>
-  <a href="https://advice.shinetext.com/articles/how-this-shine-squad-member-stopped-comparing-himself-to-others/" class="-card">
+  <a href="https://advice.theshineapp.com/articles/how-this-shine-squad-member-stopped-comparing-himself-to-others/" class="-card">
     <img class="-image" src="https://images.contentful.com/awpxl2koull4/7r7pDHn0cwek8Ckc62AAGU/6508700f4b3db94c2d990c5c4245830c/Sinclair_photo.jpg?fit=thumb&w=100&h=100">
     <p class="-testimonial">"I'm exactly where I need to be"</p>
     <p class="-name">Sinclair Ceasar</p>

--- a/hugo/layouts/robots.txt
+++ b/hugo/layouts/robots.txt
@@ -1,6 +1,6 @@
 User-agent: *
 {{ $baseUrl := .Site.BaseURL }}
-{{ if (eq  (string $baseUrl) (string "https://advice.shinetext.com/")) }}
+{{ if (eq  (string $baseUrl) (string "https://advice.theshineapp.com/")) }}
 Disallow:
 {{ else }}
 Disallow: /

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -25,7 +25,7 @@ class Header extends Component {
     return (
       <header>
         <div className="navbar">
-          <a href="https://www.shinetext.com">
+          <a href="https://www.theshineapp.com">
             <img
               className="shine-logo"
               src="https://images.ctfassets.net/awpxl2koull4/6Ge2cCqfKg0IM8CIsOMiq6/bc0dee5dd91c1b37a155c220e95893d4/shine-logo-nav-122018.png?w=100"
@@ -34,7 +34,7 @@ class Header extends Component {
 
           <div className="navbar-links-container">
             <div className="navbar-links">
-              <a href="https://join.shinetext.com/about?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+              <a href="https://www.theshineapp.com/about?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
                 About
               </a>
             </div>
@@ -42,12 +42,12 @@ class Header extends Component {
               <a href="/">Advice</a>
             </div>
             <div className="navbar-links">
-              <a href="https://join.shinetext.com/shine-at-work?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+              <a href="https://www.theshineapp.com/shine-at-work?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
                 Shine at Work
               </a>
             </div>
             <div className="navbar-links">
-              <a href="https://join.shinetext.com/get-started?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+              <a href="https://www.theshineapp.com/get-started?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
                 Get Started
               </a>
             </div>
@@ -66,7 +66,7 @@ class Header extends Component {
           />
           <ul>
             <li>
-              <a href="https://join.shinetext.com/about?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+              <a href="https://www.theshineapp.com/about?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
                 About
               </a>
             </li>
@@ -95,12 +95,12 @@ class Header extends Component {
               </ul>
             </li>
             <li>
-              <a href="https://join.shinetext.com/shine-at-work?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+              <a href="https://www.theshineapp.com/shine-at-work?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
                 Shine at Work
               </a>
             </li>
             <li>
-              <a href="https://join.shinetext.com/get-started?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
+              <a href="https://www.theshineapp.com/get-started?utm_source=Shine&utm_medium=Blog&utm_campaign=Top_Nav">
                 Get Started
               </a>
             </li>

--- a/src/less/blog-v2/main.less
+++ b/src/less/blog-v2/main.less
@@ -11,7 +11,7 @@ body {
   h2 {
     .font-poppins-bold;
     font-size: 24px;
-    letter-spacing: .1em;
+    letter-spacing: 0.1em;
   }
 }
 .latest-header {
@@ -72,28 +72,28 @@ body {
 
 // Icons
 .icon-email {
-  background-image: url("https://images.contentful.com/awpxl2koull4/5eeOIV18JOW2ewAMiEukkQ/109f351ece666845a8192bfa31c8aa73/email-social-icon.png");
+  background-image: url('https://images.contentful.com/awpxl2koull4/5eeOIV18JOW2ewAMiEukkQ/109f351ece666845a8192bfa31c8aa73/email-social-icon.png');
   background-repeat: no-repeat;
 }
 
 .icon-facebook {
-  background-image: url("https://images.contentful.com/awpxl2koull4/50UKdQRjFmcECSw6uwM02I/6d87dd816b0e2e93c6502bc2de966c71/facebook-social-icon.png");
+  background-image: url('https://images.contentful.com/awpxl2koull4/50UKdQRjFmcECSw6uwM02I/6d87dd816b0e2e93c6502bc2de966c71/facebook-social-icon.png');
   background-repeat: no-repeat;
 }
 
 .icon-linkedin {
-  background-image: url("https://images.contentful.com/awpxl2koull4/79EQTMLnuEC6yGKGm8kYkK/315b3ba3b78f0f1d4a273c8da489132e/linkedin-social-icon.png");
+  background-image: url('https://images.contentful.com/awpxl2koull4/79EQTMLnuEC6yGKGm8kYkK/315b3ba3b78f0f1d4a273c8da489132e/linkedin-social-icon.png');
   background-repeat: no-repeat;
 }
 
 .icon-pinterest {
-  background-image: url("https://assets.pinterest.com/images/pidgets/pinit_fg_en_round_red_32.png");
+  background-image: url('https://assets.pinterest.com/images/pidgets/pinit_fg_en_round_red_32.png');
   background-repeat: no-repeat;
   background-size: 35px 35px;
 }
 
 .icon-twitter {
-  background-image: url("https://images.contentful.com/awpxl2koull4/3SYgZxMlCwEiCyWc0022AQ/7111cfb7be74d3acf576ca37d82885a1/twitter-social-icon.png");
+  background-image: url('https://images.contentful.com/awpxl2koull4/3SYgZxMlCwEiCyWc0022AQ/7111cfb7be74d3acf576ca37d82885a1/twitter-social-icon.png');
   background-repeat: no-repeat;
 }
 
@@ -104,11 +104,11 @@ body {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background-image: url("https://join.shinetext.com/static/media/library-background.b066ce20.jpg");
+  background-image: url('https://www.theshineapp.com/static/media/library-background.b066ce20.jpg');
   width: 100%;
   padding: @margin-md;
   .signup-button {
-    background-color: #E4A42C;
+    background-color: #e4a42c;
     .font-poppins-bold;
     margin: @margin-xs 0;
     font-size: @font-size-btn;
@@ -118,7 +118,7 @@ body {
     height: 45px;
     width: 250px;
     border-radius: 47px;
-    color: #F8EED8;
+    color: #f8eed8;
     float: right;
     letter-spacing: 15%;
   }
@@ -137,7 +137,7 @@ body {
       text-align: center;
       width: 200px;
     }
-  }  
+  }
 }
 .join-bar-article {
   .font-poppins-bold;
@@ -145,7 +145,7 @@ body {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background-image: url("https://join.shinetext.com/static/media/library-background.b066ce20.jpg");
+  background-image: url('https://www.theshineapp.com/static/media/library-background.b066ce20.jpg');
   width: 100%;
   padding: @margin-sm;
   .join-message-article {
@@ -158,21 +158,21 @@ body {
   }
 
   img {
-    width:300px;
-    height:auto;
-    padding-bottom:20px;
+    width: 300px;
+    height: auto;
+    padding-bottom: 20px;
   }
 
   .join-message-description {
     .font-poppins;
-    text-align:center;
-    color:#f2f2f2;
+    text-align: center;
+    color: #f2f2f2;
     font-size: 18px;
   }
   @media (min-width: 768px) {
     .join-message-description {
-    width:45%;
-  }
+      width: 45%;
+    }
   }
   .signup-button-article {
     .font-poppins-bold;
@@ -183,9 +183,9 @@ body {
     justify-content: center;
     height: 50px;
     width: 250px;
-    background-color:#E4A42C;
+    background-color: #e4a42c;
     border-radius: 47px;
-    color: #F8EED8;
+    color: #f8eed8;
     float: right;
     letter-spacing: 15%;
   }
@@ -221,7 +221,7 @@ body {
 }
 
 #read-more:hover {
-  transition: .8s;
+  transition: 0.8s;
   background-color: @color-yellow;
 }
 


### PR DESCRIPTION
#### What's this PR do?
- The robots.txt file fix will the coverage issues detected for the advice.shinetext domain as well as those that'll come up for advice.theshineapp.com.
- Everything else is just for consistency and clarity. The old shinetext redirects will work, but if people hover over the link or copy and share it, we'll want to make sure we're using theshineapp.com.

#### How was this tested?
At least when updating the code, I verified every link I changed still works.