### PR TITLE
Update cta bg image with bg color

### DIFF
--- a/src/less/blog-v2/main.less
+++ b/src/less/blog-v2/main.less
@@ -145,7 +145,7 @@ body {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background-color:#347371);
+  background-color:#347371;
   width: 100%;
   padding: @margin-sm;
   .join-message-article {

--- a/src/less/blog-v2/main.less
+++ b/src/less/blog-v2/main.less
@@ -104,7 +104,7 @@ body {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background-image: url('https://www.theshineapp.com/static/media/library-background.b066ce20.jpg');
+  background-color: #347371;
   width: 100%;
   padding: @margin-md;
   .signup-button {
@@ -145,7 +145,7 @@ body {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background-image: url('https://www.theshineapp.com/static/media/library-background.b066ce20.jpg');
+  background-color:#347371);
   width: 100%;
   padding: @margin-sm;
   .join-message-article {


### PR DESCRIPTION
Since we removed the library background image from glow-web, replacing the missing background image with a solid color background to save on load time.

Places to check: bottom of advice.shinetext.com , bottom of an advice article page