### PR TITLE
Add Work category to mobile nav

### DIFF
--- a/hugo/layouts/_default/list.html
+++ b/hugo/layouts/_default/list.html
@@ -5,16 +5,18 @@
   {{ else }}
   <div class="intro-header no-img">
     <div class="container list-page">
-      {{ if in .URL "life" }}
-        {{ partial "extra/latest_header.html" "life" }}
-      {{ else if in .URL "hustle" }}
-        {{ partial "extra/latest_header.html" "hustle" }}
+      {{ if in .URL "care" }}
+        {{ partial "extra/latest_header.html" "care" }}
       {{ else if in .URL "chill" }}
         {{ partial "extra/latest_header.html" "chill" }}
-      {{ else if in .URL "play" }}
-        {{ partial "extra/latest_header.html" "play" }}
       {{ else if in .URL "grow" }}
         {{ partial "extra/latest_header.html" "grow" }}
+      {{ else if in .URL "hustle" }}
+        {{ partial "extra/latest_header.html" "hustle" }}
+      {{ else if in .URL "play" }}
+        {{ partial "extra/latest_header.html" "play" }}
+      {{ else if in .URL "work" }}
+        {{ partial "extra/latest_header.html" "work" }}
       {{ else }}
         {{ partial "extra/latest_header.html" "latest" }}
       {{ end }}

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -92,6 +92,9 @@ class Header extends Component {
                 <li>
                   <a href="/categories/play">PLAY</a>
                 </li>
+                <li>
+                  <a href="/categories/work">WORK</a>
+                </li>
               </ul>
             </li>
             <li>

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -81,6 +81,9 @@ class Header extends Component {
               />
               <ul id="category-submenu">
                 <li>
+                  <a href="/categories/care">CARE</a>
+                </li>
+                <li>
                   <a href="/categories/chill">CHILL</a>
                 </li>
                 <li>


### PR DESCRIPTION
#### What's this PR do?
Adds Work category to the mobile nav
Fixes Care heading on listing page (/categories/care/)

#### How was this tested? How should this be reviewed?
I wasn't able to test on my local because I couldn't run `run hugo-server`, going to check the deploy preview instead.