### PR TITLE
Update GTM container ID

### DIFF
--- a/config/hugo.config.base.toml
+++ b/config/hugo.config.base.toml
@@ -14,7 +14,7 @@ languageCode = "en"
 
 [params]
   description = "The daily self-care app to help you rest, heal, and grow."
-  google_tag_manager="GTM-PZHRDB"
+  google_tag_manager="GTM-MQ72WGM"
   # dateFormat = "2006, Jan 2"
   copyrightStartYear = "2015"
   infinite_scroll = true


### PR DESCRIPTION
Migrated the advice tags to the same container as theshineapp.com in order to track with Hubspot.