### PR TITLE
Remove duplicate Sumo tag

### DIFF
--- a/hugo/layouts/_default/baseof.html
+++ b/hugo/layouts/_default/baseof.html
@@ -3,7 +3,6 @@
 {{ partial "head.html" . }}
 <body>
   {{- partial "extra/gtm_body.html" . }}
-  {{- partial "extra/sumo.html" . }}
   {{- partial "extra/pinterest_save.html" . }}
   {{- partial "nav.html" . }}
   {{ block "header" . }}

--- a/hugo/layouts/partials/extra/sumo.html
+++ b/hugo/layouts/partials/extra/sumo.html
@@ -1,1 +1,0 @@
-<script async>(function(s,u,m,o,j,v){j=u.createElement(m);v=u.getElementsByTagName(m)[0];j.async=1;j.src=o;j.dataset.sumoSiteId='a67d2a27d703a5b063170cf719099ec653218686c511e6866a2c38d8dd1f52a2';v.parentNode.insertBefore(j,v)})(window,document,'script','//load.sumo.com/');</script>


### PR DESCRIPTION
#### What's this PR do?
Saw a message at the bottom of the blog that said Sumo was firing twice. This is because since we moved to the shared GTM container, Sumo is also firing from there so I'm removing the snippet from the codebase.

![image](https://user-images.githubusercontent.com/3730200/122816908-47bdf400-d2a5-11eb-81df-79734df0c902.png)

#### How was this tested? How should this be reviewed?
Will check on staging link