### PR TITLE
Passes additional err callback to getUrl lines that came from merge conflict with releases

### DIFF
--- a/hugo/lib/getUrl.js
+++ b/hugo/lib/getUrl.js
@@ -1,5 +1,5 @@
-const Promise = require("bluebird");
-const fs = Promise.promisifyAll(require("fs"));
+const Promise = require('bluebird');
+const fs = Promise.promisifyAll(require('fs'));
 
 /**
  * Get the current base for the hugo config and baseURL from Netlify ENV
@@ -11,10 +11,8 @@ const baseURL = process.env.BASE_URL
   ? `baseURL = "${process.env.BASE_URL}"\n` //format baseURL for toml file
   : `baseURL = "\/"\n`;
 
-
-fs
-  .readFileAsync(__dirname + "/../../config/hugo.config.base.toml")
-  .then(function(configData) {
+fs.readFileAsync(__dirname + '/../../config/hugo.config.base.toml')
+  .then(function (configData) {
     hugoConfig = baseURL + configData.toString(); // concat baseURL and base config file
 
     // Write hugo config file to config folder
@@ -28,9 +26,17 @@ fs
       }
     );
     // Write robots.txt file to static directory
-    let robotFileText = "User-agent: * \nDisallow: /";
-    if (baseURL !== "https://advice.shinetext.com/") {
-      fs.writeFile(__dirname + "/../static/robots.txt", robotFileText);
+    let robotFileText = 'User-agent: * \nDisallow: /';
+    if (baseURL !== 'https://advice.shinetext.com/') {
+      fs.writeFile(
+        __dirname + '/../static/robots.txt',
+        robotFileText,
+        function (err) {
+          if (err) {
+            console.log(err);
+          }
+        }
+      );
     }
   })
   .catch(function (error) {


### PR DESCRIPTION
#### What's this PR do?
Passes an additional err callback to new `getUrl.js` lines that came from merge conflict with `releases.` Will need this additional cb in order for build to pass in build image update.

And more prettier formatting. Not sure why this didn't come up the 1st time around.

#### How was this tested? How should this be reviewed?
Will check deploy preview and build status.

#### What are the relevant tickets?
https://www.notion.so/shinetext/Sept-19-deadline-Netlify-build-image-migration-29e199347ad24469b6f1cdbeed0bb07d

